### PR TITLE
Enable .eosgi.dist.xml placed in the project

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -29,7 +29,7 @@
 
   <groupId>org.everit.osgi.dev</groupId>
   <artifactId>eosgi-maven-plugin</artifactId>
-  <version>4.1.3</version>
+  <version>4.2.0-SNAPSHOT</version>
 
   <packaging>maven-plugin</packaging>
 


### PR DESCRIPTION
If the file is present in the environmentRootFolder it will overwrite the one unpacked from the distPackageFile. Also, in this case the later one does not have to exist